### PR TITLE
Fix wrong distance attr value parser

### DIFF
--- a/src/lib/components/burger.ts
+++ b/src/lib/components/burger.ts
@@ -148,7 +148,7 @@ export abstract class Burger extends HTMLElement {
   attributeChangedCallback(prop: string, oldVal: string, newVal: string): void {
     if (oldVal !== newVal) {
       let value: unknown = newVal;
-      if (prop === 'size' || prop === 'distance') {
+      if (prop === 'size' || prop === 'duration') {
         value = newVal === null ? null : Number(newVal);
       } else if (prop === 'pressed') {
         value = newVal !== null;

--- a/src/lib/components/burger.ts
+++ b/src/lib/components/burger.ts
@@ -148,7 +148,7 @@ export abstract class Burger extends HTMLElement {
   attributeChangedCallback(prop: string, oldVal: string, newVal: string): void {
     if (oldVal !== newVal) {
       let value: unknown = newVal;
-      if (prop === 'size' || prop === 'duration') {
+      if (prop == 'size' || prop == 'duration') {
         value = newVal === null ? null : Number(newVal);
       } else if (prop === 'pressed') {
         value = newVal !== null;

--- a/src/test/hamburger.test.ts
+++ b/src/test/hamburger.test.ts
@@ -67,9 +67,14 @@ describe('hamburger', () => {
       expect(burger.direction).to.equal('right');
     });
 
+    it('should set duration property when attribute changes', () => {
+      burger.setAttribute('duration', '0.5');
+      expect(burger.duration).to.equal(0.5);
+    });
+
     it('should set distance property when attribute changes', () => {
-      burger.setAttribute('distance', '0.5');
-      expect(burger.distance).to.equal(0.5);
+      burger.setAttribute('distance', 'lg');
+      expect(burger.distance).to.equal('lg');
     });
 
     it('should set size property when attribute changes', () => {


### PR DESCRIPTION
The `distance` attr value is parsed as number while it's an enum value `'sm' | 'md' | 'lg'` in the typings. At the same time there's no number coercion and tests for the `duration` attribute.

I believe there was a typo at some point. And here's the proposed fix

_Brace yourself, the Hacktoberfest is coming! :grin:_