### PR TITLE
Proposal: Attributes as properties

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -156,7 +156,7 @@
       import '../twirl-burger.js';
     </script>
     <script type="module">
-      import { defaultProps } from '../lib/components/burger.js';
+      import { defaultProps } from './demo-snippet.js';
       import './demo-snippet.js';
 
       const demo = document.querySelector('demo-snippet');

--- a/src/demo/demo-snippet.ts
+++ b/src/demo/demo-snippet.ts
@@ -3,8 +3,17 @@ import { registerLanguages } from 'highlight-ts/es/languages.js';
 import { XML } from 'highlight-ts/es/languages/xml.js';
 import { JavaScript } from 'highlight-ts/es/languages/javascript.js';
 import { init, process } from 'highlight-ts/es/process.js';
-import { defaultProps } from '../lib/components/burger.js';
 import type { BurgerProps } from '../lib/types.js';
+
+export const defaultProps: BurgerProps = {
+  size: 32,
+  direction: 'left',
+  distance: 'md',
+  duration: 0.4,
+  label: 'hamburger',
+  easing: 'cubic-bezier(0, 0, 0, 1)',
+  pressed: false
+};
 
 registerLanguages(XML, JavaScript);
 

--- a/src/lib/components/direction-burger.ts
+++ b/src/lib/components/direction-burger.ts
@@ -1,5 +1,4 @@
 import { Burger } from './burger.js';
-import { props, update } from '../internals';
 
 export abstract class DirectionBurger extends Burger {
   static get observedAttributes(): string[] {
@@ -12,11 +11,11 @@ export abstract class DirectionBurger extends Burger {
    * @default left
    */
   get direction(): 'left' | 'right' {
-    return this[props].direction;
+    const direction = this.getAttribute('direction');
+    return direction === 'right' ? 'right' : 'left';
   }
 
-  set direction(distance: 'left' | 'right') {
-    this[props].direction = distance;
-    this[update]();
+  set direction(direction: 'left' | 'right') {
+    this.setAttribute('direction', direction);
   }
 }


### PR DESCRIPTION
Hey! Me again :smile: 

Not that it's a ready-to-merge MR, rather a suggestion.

What if instead of syncing manually internal properties and attribute values we could just use the attributes as a state. It has several benefits:

- No need for handling attr change and property change separately
- Correct `removeAttribute()` handling out of the box
- Better separation of the basic abstract classes
- 0.02 Kb less in `size-limit`

----

The idea is using `attributeChangedCallback` for handling all the changes. _In fact, `.attributeChangedCallback()` and `[update]()` now can be merged into one function, but would clutter the diff._

- The attributes are *public*, *unsanitized* values. Meaning, the user can set any value they want. That's really how HTML usually works.
- The properties setters are *public* and *unsanitized*. Again, it mimics the DOM behavior: you can set `el.zIndex = 'totally garbage'` and it would just handle it as `0`
- The property getters are *public* and **sanitized**. They are also used for the internal machinery (this part is unchanged).

In short: 

```ts
burger.size = 'some invalid value';
burger.size === 'md'; // sanitized: the default value;
burger.getAttribute('size'); // 'some invalid value' (unsanitized)
```

----

I've run the tests and size-limit so this time hopefully I won't drop a broken code in my PR