### PR TITLE
Reflect pressed property to attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ cross-burger {
   color: #999;
 }
 
+cross-burger[pressed] {
+  color: #666;
+}
+
 cross-burger::part(bar) {
   border-radius: 9em;
 }

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
   "size-limit": [
     {
       "path": "cross-burger.js",
-      "limit": "1.6 KB"
+      "limit": "1.7 KB"
     },
     {
       "path": "fade-burger.js",
@@ -144,7 +144,7 @@
     },
     {
       "path": "squeeze-burger.js",
-      "limit": "1.6 KB"
+      "limit": "1.7 KB"
     },
     {
       "path": "tilt-burger.js",

--- a/src/lib/components/burger.ts
+++ b/src/lib/components/burger.ts
@@ -103,6 +103,7 @@ export abstract class Burger extends HTMLElement {
 
   set pressed(pressed: boolean) {
     this[props].pressed = pressed;
+    this.toggleAttribute('pressed', !!pressed);
     this[btn] && this[btn].setAttribute('aria-pressed', `${!!pressed}`);
     this[update]();
   }

--- a/src/lib/components/burger.ts
+++ b/src/lib/components/burger.ts
@@ -95,6 +95,7 @@ export abstract class Burger extends HTMLElement {
   /**
    * Set to true when element is pressed.
    * @type {boolean}
+   * @attr pressed
    * @default false
    */
   get pressed(): boolean {

--- a/src/test/hamburger.test.ts
+++ b/src/test/hamburger.test.ts
@@ -91,6 +91,11 @@ describe('hamburger', () => {
       burger.setAttribute('pressed', '');
       expect(burger.pressed).to.equal(true);
     });
+
+    it('should set pressed attribute when property changes', () => {
+      burger.pressed = true;
+      expect(burger.hasAttribute('pressed')).to.be.true;
+    });
   });
 
   describe('native button', () => {


### PR DESCRIPTION
Unlike all the other properties, `pressed` makes sense in terms of styling the component based on its state.
As we don't have support for custom pseudo classes yet, let's reflect this property to attribute.